### PR TITLE
Core creds api change

### DIFF
--- a/src/ruby/bin/apis/pubsub_demo.rb
+++ b/src/ruby/bin/apis/pubsub_demo.rb
@@ -66,7 +66,7 @@ end
 
 # creates a SSL Credentials from the production certificates.
 def ssl_creds
-  GRPC::Core::Credentials.new(load_prod_cert)
+  GRPC::Core::ChannelCredentials.new(load_prod_cert)
 end
 
 # Builds the metadata authentication update proc.

--- a/src/ruby/bin/math_client.rb
+++ b/src/ruby/bin/math_client.rb
@@ -102,7 +102,7 @@ end
 
 def test_creds
   certs = load_test_certs
-  GRPC::Core::Credentials.new(certs[0])
+  GRPC::Core::ChannelCredentials.new(certs[0])
 end
 
 def main

--- a/src/ruby/bin/noproto_client.rb
+++ b/src/ruby/bin/noproto_client.rb
@@ -68,7 +68,7 @@ end
 
 def test_creds
   certs = load_test_certs
-  GRPC::Core::Credentials.new(certs[0])
+  GRPC::Core::ChannelCredentials.new(certs[0])
 end
 
 def main

--- a/src/ruby/ext/grpc/rb_channel.c
+++ b/src/ruby/ext/grpc/rb_channel.c
@@ -41,8 +41,8 @@
 #include "rb_grpc.h"
 #include "rb_call.h"
 #include "rb_channel_args.h"
+#include "rb_channel_credentials.h"
 #include "rb_completion_queue.h"
-#include "rb_credentials.h"
 #include "rb_server.h"
 
 /* id_channel is the name of the hidden ivar that preserves a reference to the
@@ -134,8 +134,8 @@ static VALUE grpc_rb_channel_init(int argc, VALUE *argv, VALUE self) {
   VALUE credentials = Qnil;
   VALUE target = Qnil;
   grpc_rb_channel *wrapper = NULL;
-  grpc_credentials *creds = NULL;
   grpc_channel *ch = NULL;
+  grpc_channel_credentials *creds = NULL;
   char *target_chars = NULL;
   grpc_channel_args args;
   MEMZERO(&args, grpc_channel_args, 1);
@@ -149,7 +149,7 @@ static VALUE grpc_rb_channel_init(int argc, VALUE *argv, VALUE self) {
   if (credentials == Qnil) {
     ch = grpc_insecure_channel_create(target_chars, &args, NULL);
   } else {
-    creds = grpc_rb_get_wrapped_credentials(credentials);
+    creds = grpc_rb_get_wrapped_channel_credentials(credentials);
     ch = grpc_secure_channel_create(creds, target_chars, &args, NULL);
   }
   if (args.args != NULL) {

--- a/src/ruby/ext/grpc/rb_channel_credentials.c
+++ b/src/ruby/ext/grpc/rb_channel_credentials.c
@@ -31,7 +31,7 @@
  *
  */
 
-#include "rb_credentials.h"
+#include "rb_channel_credentials.h"
 
 #include <ruby/ruby.h>
 
@@ -40,32 +40,33 @@
 
 #include "rb_grpc.h"
 
-/* grpc_rb_cCredentials is the ruby class that proxies grpc_credentials. */
-static VALUE grpc_rb_cCredentials = Qnil;
+/* grpc_rb_cChannelCredentials is the ruby class that proxies
+   grpc_channel_credentials. */
+static VALUE grpc_rb_cChannelCredentials = Qnil;
 
-/* grpc_rb_credentials wraps a grpc_credentials.  It provides a
+/* grpc_rb_channel_credentials wraps a grpc_channel_credentials.  It provides a
  * peer ruby object, 'mark' to minimize copying when a credential is
  * created from ruby. */
-typedef struct grpc_rb_credentials {
+typedef struct grpc_rb_channel_credentials {
   /* Holder of ruby objects involved in constructing the credentials */
   VALUE mark;
 
   /* The actual credentials */
-  grpc_credentials *wrapped;
-} grpc_rb_credentials;
+  grpc_channel_credentials *wrapped;
+} grpc_rb_channel_credentials;
 
 /* Destroys the credentials instances. */
-static void grpc_rb_credentials_free(void *p) {
-  grpc_rb_credentials *wrapper = NULL;
+static void grpc_rb_channel_credentials_free(void *p) {
+  grpc_rb_channel_credentials *wrapper = NULL;
   if (p == NULL) {
     return;
   };
-  wrapper = (grpc_rb_credentials *)p;
+  wrapper = (grpc_rb_channel_credentials *)p;
 
   /* Delete the wrapped object if the mark object is Qnil, which indicates that
    * no other object is the actual owner. */
   if (wrapper->wrapped != NULL && wrapper->mark == Qnil) {
-    grpc_credentials_release(wrapper->wrapped);
+    grpc_channel_credentials_release(wrapper->wrapped);
     wrapper->wrapped = NULL;
   }
 
@@ -73,12 +74,12 @@ static void grpc_rb_credentials_free(void *p) {
 }
 
 /* Protects the mark object from GC */
-static void grpc_rb_credentials_mark(void *p) {
-  grpc_rb_credentials *wrapper = NULL;
+static void grpc_rb_channel_credentials_mark(void *p) {
+  grpc_rb_channel_credentials *wrapper = NULL;
   if (p == NULL) {
     return;
   }
-  wrapper = (grpc_rb_credentials *)p;
+  wrapper = (grpc_rb_channel_credentials *)p;
 
   /* If it's not already cleaned up, mark the mark object */
   if (wrapper->mark != Qnil) {
@@ -86,29 +87,29 @@ static void grpc_rb_credentials_mark(void *p) {
   }
 }
 
-static rb_data_type_t grpc_rb_credentials_data_type = {
-    "grpc_credentials",
-    {grpc_rb_credentials_mark, grpc_rb_credentials_free,
+static rb_data_type_t grpc_rb_channel_credentials_data_type = {
+    "grpc_channel_credentials",
+    {grpc_rb_channel_credentials_mark, grpc_rb_channel_credentials_free,
      GRPC_RB_MEMSIZE_UNAVAILABLE, {NULL, NULL}},
     NULL,
     NULL,
     RUBY_TYPED_FREE_IMMEDIATELY};
 
-/* Allocates Credential instances.
+/* Allocates ChannelCredential instances.
    Provides safe initial defaults for the instance fields. */
-static VALUE grpc_rb_credentials_alloc(VALUE cls) {
-  grpc_rb_credentials *wrapper = ALLOC(grpc_rb_credentials);
+static VALUE grpc_rb_channel_credentials_alloc(VALUE cls) {
+  grpc_rb_channel_credentials *wrapper = ALLOC(grpc_rb_channel_credentials);
   wrapper->wrapped = NULL;
   wrapper->mark = Qnil;
-  return TypedData_Wrap_Struct(cls, &grpc_rb_credentials_data_type, wrapper);
+  return TypedData_Wrap_Struct(cls, &grpc_rb_channel_credentials_data_type, wrapper);
 }
 
-/* Clones Credentials instances.
-   Gives Credentials a consistent implementation of Ruby's object copy/dup
+/* Clones ChannelCredentials instances.
+   Gives ChannelCredentials a consistent implementation of Ruby's object copy/dup
    protocol. */
-static VALUE grpc_rb_credentials_init_copy(VALUE copy, VALUE orig) {
-  grpc_rb_credentials *orig_cred = NULL;
-  grpc_rb_credentials *copy_cred = NULL;
+static VALUE grpc_rb_channel_credentials_init_copy(VALUE copy, VALUE orig) {
+  grpc_rb_channel_credentials *orig_cred = NULL;
+  grpc_rb_channel_credentials *copy_cred = NULL;
 
   if (copy == orig) {
     return copy;
@@ -116,83 +117,22 @@ static VALUE grpc_rb_credentials_init_copy(VALUE copy, VALUE orig) {
 
   /* Raise an error if orig is not a credentials object or a subclass. */
   if (TYPE(orig) != T_DATA ||
-      RDATA(orig)->dfree != (RUBY_DATA_FUNC)grpc_rb_credentials_free) {
-    rb_raise(rb_eTypeError, "not a %s", rb_obj_classname(grpc_rb_cCredentials));
+      RDATA(orig)->dfree != (RUBY_DATA_FUNC)grpc_rb_channel_credentials_free) {
+    rb_raise(rb_eTypeError, "not a %s",
+             rb_obj_classname(grpc_rb_cChannelCredentials));
   }
 
-  TypedData_Get_Struct(orig, grpc_rb_credentials,
-                       &grpc_rb_credentials_data_type, orig_cred);
-  TypedData_Get_Struct(copy, grpc_rb_credentials,
-                       &grpc_rb_credentials_data_type, copy_cred);
+  TypedData_Get_Struct(orig, grpc_rb_channel_credentials,
+                       &grpc_rb_channel_credentials_data_type, orig_cred);
+  TypedData_Get_Struct(copy, grpc_rb_channel_credentials,
+                       &grpc_rb_channel_credentials_data_type, copy_cred);
 
   /* use ruby's MEMCPY to make a byte-for-byte copy of the credentials
    * wrapper object. */
-  MEMCPY(copy_cred, orig_cred, grpc_rb_credentials, 1);
+  MEMCPY(copy_cred, orig_cred, grpc_rb_channel_credentials, 1);
   return copy;
 }
 
-/*
-  call-seq:
-    creds = Credentials.default()
-    Creates the default credential instances. */
-static VALUE grpc_rb_default_credentials_create(VALUE cls) {
-  grpc_rb_credentials *wrapper = ALLOC(grpc_rb_credentials);
-  wrapper->wrapped = grpc_google_default_credentials_create();
-  if (wrapper->wrapped == NULL) {
-    rb_raise(rb_eRuntimeError,
-             "could not create default credentials, not sure why");
-    return Qnil;
-  }
-
-  wrapper->mark = Qnil;
-  return TypedData_Wrap_Struct(cls, &grpc_rb_credentials_data_type, wrapper);
-}
-
-/*
-  call-seq:
-    creds = Credentials.compute_engine()
-    Creates the default credential instances. */
-static VALUE grpc_rb_compute_engine_credentials_create(VALUE cls) {
-  grpc_rb_credentials *wrapper = ALLOC(grpc_rb_credentials);
-  wrapper->wrapped = grpc_google_compute_engine_credentials_create(NULL);
-  if (wrapper->wrapped == NULL) {
-    rb_raise(rb_eRuntimeError,
-             "could not create composite engine credentials, not sure why");
-    return Qnil;
-  }
-
-  wrapper->mark = Qnil;
-  return TypedData_Wrap_Struct(cls, &grpc_rb_credentials_data_type, wrapper);
-}
-
-/*
-  call-seq:
-    creds1 = ...
-    creds2 = ...
-    creds3 = creds1.add(creds2)
-    Creates the default credential instances. */
-static VALUE grpc_rb_composite_credentials_create(VALUE self, VALUE other) {
-  grpc_rb_credentials *self_wrapper = NULL;
-  grpc_rb_credentials *other_wrapper = NULL;
-  grpc_rb_credentials *wrapper = NULL;
-
-  TypedData_Get_Struct(self, grpc_rb_credentials,
-                       &grpc_rb_credentials_data_type, self_wrapper);
-  TypedData_Get_Struct(other, grpc_rb_credentials,
-                       &grpc_rb_credentials_data_type, other_wrapper);
-  wrapper = ALLOC(grpc_rb_credentials);
-  wrapper->wrapped = grpc_composite_credentials_create(
-      self_wrapper->wrapped, other_wrapper->wrapped, NULL);
-  if (wrapper->wrapped == NULL) {
-    rb_raise(rb_eRuntimeError,
-             "could not create composite credentials, not sure why");
-    return Qnil;
-  }
-
-  wrapper->mark = Qnil;
-  return TypedData_Wrap_Struct(grpc_rb_cCredentials,
-                               &grpc_rb_credentials_data_type, wrapper);
-}
 
 /* The attribute used on the mark object to hold the pem_root_certs. */
 static ID id_pem_root_certs;
@@ -213,12 +153,12 @@ static ID id_pem_cert_chain;
     pem_private_key: (optional) PEM encoding of the client's private key
     pem_cert_chain: (optional) PEM encoding of the client's cert chain
     Initializes Credential instances. */
-static VALUE grpc_rb_credentials_init(int argc, VALUE *argv, VALUE self) {
+static VALUE grpc_rb_channel_credentials_init(int argc, VALUE *argv, VALUE self) {
   VALUE pem_root_certs = Qnil;
   VALUE pem_private_key = Qnil;
   VALUE pem_cert_chain = Qnil;
-  grpc_rb_credentials *wrapper = NULL;
-  grpc_credentials *creds = NULL;
+  grpc_rb_channel_credentials *wrapper = NULL;
+  grpc_channel_credentials *creds = NULL;
   grpc_ssl_pem_key_cert_pair key_cert_pair;
   MEMZERO(&key_cert_pair, grpc_ssl_pem_key_cert_pair, 1);
   /* TODO: Remove mandatory arg when we support default roots. */
@@ -226,8 +166,8 @@ static VALUE grpc_rb_credentials_init(int argc, VALUE *argv, VALUE self) {
   rb_scan_args(argc, argv, "12", &pem_root_certs, &pem_private_key,
                &pem_cert_chain);
 
-  TypedData_Get_Struct(self, grpc_rb_credentials,
-                       &grpc_rb_credentials_data_type, wrapper);
+  TypedData_Get_Struct(self, grpc_rb_channel_credentials,
+                       &grpc_rb_channel_credentials_data_type, wrapper);
   if (pem_root_certs == Qnil) {
     rb_raise(rb_eRuntimeError,
              "could not create a credential: nil pem_root_certs");
@@ -256,39 +196,30 @@ static VALUE grpc_rb_credentials_init(int argc, VALUE *argv, VALUE self) {
   return self;
 }
 
-void Init_grpc_credentials() {
-  grpc_rb_cCredentials =
-      rb_define_class_under(grpc_rb_mGrpcCore, "Credentials", rb_cObject);
+void Init_grpc_channel_credentials() {
+  grpc_rb_cChannelCredentials =
+      rb_define_class_under(grpc_rb_mGrpcCore, "ChannelCredentials", rb_cObject);
 
   /* Allocates an object managed by the ruby runtime */
-  rb_define_alloc_func(grpc_rb_cCredentials, grpc_rb_credentials_alloc);
+  rb_define_alloc_func(grpc_rb_cChannelCredentials,
+                       grpc_rb_channel_credentials_alloc);
 
   /* Provides a ruby constructor and support for dup/clone. */
-  rb_define_method(grpc_rb_cCredentials, "initialize", grpc_rb_credentials_init,
-                   -1);
-  rb_define_method(grpc_rb_cCredentials, "initialize_copy",
-                   grpc_rb_credentials_init_copy, 1);
-
-  /* Provide static funcs that create new special instances. */
-  rb_define_singleton_method(grpc_rb_cCredentials, "default",
-                             grpc_rb_default_credentials_create, 0);
-
-  rb_define_singleton_method(grpc_rb_cCredentials, "compute_engine",
-                             grpc_rb_compute_engine_credentials_create, 0);
-
-  /* Provide other methods. */
-  rb_define_method(grpc_rb_cCredentials, "compose",
-                   grpc_rb_composite_credentials_create, 1);
+  rb_define_method(grpc_rb_cChannelCredentials, "initialize",
+                   grpc_rb_channel_credentials_init, -1);
+  rb_define_method(grpc_rb_cChannelCredentials, "initialize_copy",
+                   grpc_rb_channel_credentials_init_copy, 1);
 
   id_pem_cert_chain = rb_intern("__pem_cert_chain");
   id_pem_private_key = rb_intern("__pem_private_key");
   id_pem_root_certs = rb_intern("__pem_root_certs");
 }
 
-/* Gets the wrapped grpc_credentials from the ruby wrapper */
-grpc_credentials *grpc_rb_get_wrapped_credentials(VALUE v) {
-  grpc_rb_credentials *wrapper = NULL;
-  TypedData_Get_Struct(v, grpc_rb_credentials, &grpc_rb_credentials_data_type,
+/* Gets the wrapped grpc_channel_credentials from the ruby wrapper */
+grpc_channel_credentials *grpc_rb_get_wrapped_channel_credentials(VALUE v) {
+  grpc_rb_channel_credentials *wrapper = NULL;
+  TypedData_Get_Struct(v, grpc_rb_channel_credentials,
+                       &grpc_rb_channel_credentials_data_type,
                        wrapper);
   return wrapper->wrapped;
 }

--- a/src/ruby/ext/grpc/rb_channel_credentials.h
+++ b/src/ruby/ext/grpc/rb_channel_credentials.h
@@ -38,10 +38,10 @@
 
 #include <grpc/grpc_security.h>
 
-/* Initializes the ruby Credentials class. */
-void Init_grpc_credentials();
+/* Initializes the ruby ChannelCredentials class. */
+void Init_grpc_channel_credentials();
 
 /* Gets the wrapped credentials from the ruby wrapper */
-grpc_credentials* grpc_rb_get_wrapped_credentials(VALUE v);
+grpc_channel_credentials* grpc_rb_get_wrapped_channel_credentials(VALUE v);
 
 #endif /* GRPC_RB_CREDENTIALS_H_ */

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -42,9 +42,9 @@
 #include <grpc/support/time.h>
 #include "rb_call.h"
 #include "rb_channel.h"
+#include "rb_channel_credentials.h"
 #include "rb_completion_queue.h"
 #include "rb_server.h"
-#include "rb_credentials.h"
 #include "rb_server_credentials.h"
 
 static VALUE grpc_rb_cTimeVal = Qnil;
@@ -300,7 +300,7 @@ void Init_grpc() {
   Init_grpc_channel();
   Init_grpc_completion_queue();
   Init_grpc_call();
-  Init_grpc_credentials();
+  Init_grpc_channel_credentials();
   Init_grpc_server();
   Init_grpc_server_credentials();
   Init_grpc_status_codes();

--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -51,7 +51,9 @@ module GRPC
       end
       kw['grpc.primary_user_agent'] = "grpc-ruby/#{VERSION}"
       return Core::Channel.new(host, kw) if creds.nil?
-      fail(TypeError, '!Credentials') unless creds.is_a?(Core::Credentials)
+      unless creds.is_a?(Core::ChannelCredentials)
+        fail(TypeError, '!ChannelCredentials')
+      end
       Core::Channel.new(host, kw, creds)
     end
 
@@ -106,7 +108,7 @@ module GRPC
     # @param q [Core::CompletionQueue] used to wait for events
     # @param channel_override [Core::Channel] a pre-created channel
     # @param timeout [Number] the default timeout to use in requests
-    # @param creds [Core::Credentials] the channel
+    # @param creds [Core::ChannelCredentials] the channel credentials
     # @param update_metadata a func that updates metadata as described above
     # @param kw [KeywordArgs]the channel arguments
     def initialize(host, q,

--- a/src/ruby/pb/test/client.rb
+++ b/src/ruby/pb/test/client.rb
@@ -86,13 +86,13 @@ end
 # creates SSL Credentials from the test certificates.
 def test_creds
   certs = load_test_certs
-  GRPC::Core::Credentials.new(certs[0])
+  GRPC::Core::ChannelCredentials.new(certs[0])
 end
 
 # creates SSL Credentials from the production certificates.
 def prod_creds
   cert_text = load_prod_cert
-  GRPC::Core::Credentials.new(cert_text)
+  GRPC::Core::ChannelCredentials.new(cert_text)
 end
 
 # creates the SSL Credentials.

--- a/src/ruby/spec/channel_credentials_spec.rb
+++ b/src/ruby/spec/channel_credentials_spec.rb
@@ -29,8 +29,8 @@
 
 require 'grpc'
 
-describe GRPC::Core::Credentials do
-  Credentials = GRPC::Core::Credentials
+describe GRPC::Core::ChannelCredentials do
+  ChannelCredentials = GRPC::Core::ChannelCredentials
 
   def load_test_certs
     test_root = File.join(File.dirname(__FILE__), 'testdata')
@@ -40,32 +40,24 @@ describe GRPC::Core::Credentials do
 
   describe '#new' do
     it 'can be constructed with fake inputs' do
-      expect { Credentials.new('root_certs', 'key', 'cert') }.not_to raise_error
+      blk = proc  { ChannelCredentials.new('root_certs', 'key', 'cert') }
+      expect(&blk).not_to raise_error
     end
 
     it 'it can be constructed using specific test certificates' do
       certs = load_test_certs
-      expect { Credentials.new(*certs) }.not_to raise_error
+      expect { ChannelCredentials.new(*certs) }.not_to raise_error
     end
 
     it 'can be constructed with server roots certs only' do
       root_cert, _, _ = load_test_certs
-      expect { Credentials.new(root_cert) }.not_to raise_error
+      expect { ChannelCredentials.new(root_cert) }.not_to raise_error
     end
 
     it 'cannot be constructed with a nil server roots' do
       _, client_key, client_chain = load_test_certs
-      blk = proc { Credentials.new(nil, client_key, client_chain) }
+      blk = proc { ChannelCredentials.new(nil, client_key, client_chain) }
       expect(&blk).to raise_error
-    end
-  end
-
-  describe '#compose' do
-    it 'cannot be completed OK with 2 SSL creds' do
-      certs = load_test_certs
-      cred1 = Credentials.new(*certs)
-      cred2 = Credentials.new(*certs)
-      expect { cred1.compose(cred2) }.to raise_error
     end
   end
 end

--- a/src/ruby/spec/channel_spec.rb
+++ b/src/ruby/spec/channel_spec.rb
@@ -40,7 +40,7 @@ describe GRPC::Core::Channel do
   let(:cq) { GRPC::Core::CompletionQueue.new }
 
   def create_test_cert
-    GRPC::Core::Credentials.new(load_test_certs[0])
+    GRPC::Core::ChannelCredentials.new(load_test_certs[0])
   end
 
   shared_examples '#new' do

--- a/src/ruby/spec/client_server_spec.rb
+++ b/src/ruby/spec/client_server_spec.rb
@@ -431,7 +431,7 @@ describe 'the secure http client/server' do
     @server.start
     args = { Channel::SSL_TARGET => 'foo.test.google.fr' }
     @ch = Channel.new("0.0.0.0:#{server_port}", args,
-                      GRPC::Core::Credentials.new(certs[0], nil, nil))
+                      GRPC::Core::ChannelCredentials.new(certs[0], nil, nil))
   end
 
   after(:example) do

--- a/src/ruby/spec/generic/client_stub_spec.rb
+++ b/src/ruby/spec/generic/client_stub_spec.rb
@@ -113,7 +113,7 @@ describe 'ClientStub' do
         opts = {
           GRPC::Core::Channel::SSL_TARGET => 'foo.test.google.fr',
           a_channel_arg: 'an_arg',
-          creds: GRPC::Core::Credentials.new(certs[0], nil, nil)
+          creds: GRPC::Core::ChannelCredentials.new(certs[0], nil, nil)
         }
         GRPC::ClientStub.new(fake_host, @cq, **opts)
       end


### PR DESCRIPTION
Updates Ruby gRPC with the Core Creds API change.

N.B This removes the use of ruby-level credentials that have changed to call_credentials, as they were not used anywhere in the surface as of this branch.   This will simplify a future merge of this change into the main branch
